### PR TITLE
[FEATURE] Recursively merge test trees

### DIFF
--- a/lib/add-in-repo-tests-to-host.js
+++ b/lib/add-in-repo-tests-to-host.js
@@ -7,13 +7,28 @@ const Funnel = require('broccoli-funnel');
 const generateTreeFromPath = path =>
   existsSync(path) ? new WatchedDir(path) : null;
 
-const getInRepoAddonTestTrees = inRepoAddons =>
-  inRepoAddons.map(inRepoAddon => {
+const getInRepoAddonTestTrees = (inRepoAddons, predicate) => {
+  if (inRepoAddons.length === 0) {
+    return [null];
+  }
+
+  return inRepoAddons.map(inRepoAddon => {
     const inRepoAddonTestPath = `${inRepoAddon.root}/tests`;
-    return existsSync(inRepoAddonTestPath)
+    const nestedAddons = inRepoAddon.addons || [];
+    const nestedAddonsTestTrees = getInRepoAddonTestTrees(
+      nestedAddons.filter(predicate),
+      predicate
+    );
+
+    const inRepoAddonTestTree = existsSync(inRepoAddonTestPath)
       ? new Funnel(inRepoAddonTestPath, { destDir: inRepoAddon.name })
       : null;
+
+    return mergeTrees(
+      [inRepoAddonTestTree, ...nestedAddonsTestTrees].filter(Boolean)
+    );
   });
+};
 
 module.exports = (emberProject, predicate) => {
   if (!emberProject || !emberProject.root) {
@@ -22,7 +37,10 @@ module.exports = (emberProject, predicate) => {
 
   const projectTestsPath = path.join(emberProject.root, 'tests');
   const inRepoAddons = emberProject.addons.filter(predicate);
-  const inRepoAddonsTestTrees = getInRepoAddonTestTrees(inRepoAddons);
+  const inRepoAddonsTestTrees = getInRepoAddonTestTrees(
+    inRepoAddons,
+    predicate
+  );
 
   return mergeTrees(
     [...inRepoAddonsTestTrees, generateTreeFromPath(projectTestsPath)].filter(


### PR DESCRIPTION
Before, we were only applying the merge logic one level deep.

We need to recurisvely apply the predicate and merge test trees for all of the
addons.